### PR TITLE
remove unused clrWizardOpen binding

### DIFF
--- a/src/app/configuration/environments/edit-environment/edit-environment.component.html
+++ b/src/app/configuration/environments/edit-environment/edit-environment.component.html
@@ -1,4 +1,4 @@
-<clr-wizard #wizard [(clrWizardOpen)]="wizardOpen" clrWizardSize="xl" (clrWizardOnFinish)="saveEnvironment()">
+<clr-wizard #wizard clrWizardSize="xl" (clrWizardOnFinish)="saveEnvironment()">
     <clr-wizard-title>Edit Environment</clr-wizard-title>
 
     <clr-wizard-button [type]="'cancel'">Cancel</clr-wizard-button>


### PR DESCRIPTION
The build currently fails with the following error:

```
Step 3/10 : RUN $(npm bin)/ng build --prod --aot
 ---> Running in 08e43a1c0043
ERROR in src/app/configuration/environments/edit-environment/edit-environment.component.html(1,21): Property 'wizardOpen' does not exist on type 'EditEnvironmentComponent'.
src/app/configuration/environments/edit-environment/edit-environment.component.html(1,21): Property 'wizardOpen' does not exist on type 'EditEnvironmentComponent'.
```

This is due to setting the `clrWizardOpen` property and not using it (since the wizard is opened through other functionality).