### PR TITLE
Fix unique accesscode check

### DIFF
--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -107,7 +107,7 @@ export class NewScheduledEventComponent implements OnInit {
 
   public uniqueAccessCode(): ValidatorFn {
     return (control: AbstractControl): { [key: string]: any } | null => {
-      if (!control.value || this.scheduledEvents.filter(el => el.access_code === control.value).length > 0) {
+      if (!control.value || this.scheduledEvents.filter(el => el.access_code === control.value && (!this.event || this.event.access_code !== control.value)).length > 0) {
         return {
           notUnqiue: true
         };


### PR DESCRIPTION
This PR fixes an issue with editing scheduledevents. 

The Commit https://github.com/hobbyfarm/admin-ui/commit/19b474f3903903df5ede6027c5da500c24a722a9 brought in a check to verify that the Access Code does not already exists. However this was also applied for editing SEs which makes it impossible to edit SEs.
This PR fixes this check, so that the AC of the SE that we are currently editing is not considered a duplicate.