### PR TITLE
Fix Menu Position

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -14,12 +14,12 @@
 </div>
 
 <div class="header-actions">
-    <clr-dropdown clrMenuPosition="bottom-right">
+    <clr-dropdown>
         <button class="nav-text" clrDropdownToggle>
             {{email}}
             <clr-icon shape="caret down"></clr-icon>
         </button>
-        <clr-dropdown-menu>
+        <clr-dropdown-menu *clrIfOpen clrPosition="bottom-right">
             <a (click)="about()" clrDropdownItem>About</a>
             <a (click)="logout()" clrDropdownItem>Logout</a>
         </clr-dropdown-menu>


### PR DESCRIPTION
This PR fixes the position for the top right menu in the header of the admin-ui. 

![menu-fix](https://user-images.githubusercontent.com/86782124/133048804-cd31bbaa-a225-4360-88da-56f4d63a2fc0.PNG)

instead of 

![menu-old](https://user-images.githubusercontent.com/86782124/133048840-ecf0eae2-526d-46ea-a49e-6c3506e1afda.PNG)
