### PR TITLE
Update restricted bind and on demand for scheduledEvents

### DIFF
--- a/src/app/data/scheduledevent.service.ts
+++ b/src/app/data/scheduledevent.service.ts
@@ -65,7 +65,9 @@ export class ScheduledeventService {
       .set("start_time", formatDate(se.start_time, "E LLL dd HH:mm:ss UTC yyyy", "en-US", "UTC"))
       .set("end_time", formatDate(se.end_time, "E LLL dd HH:mm:ss UTC yyyy", "en-US", "UTC"))
       .set("required_vms", JSON.stringify(se.required_vms))
-      .set("access_code", se.access_code);
+      .set("access_code", se.access_code.toLocaleLowerCase()) // this needs to be lower case because of RFC-1123
+      .set("disable_restriction", JSON.stringify(se.disable_restriction))
+      .set("on_demand", JSON.stringify(se.on_demand));
 
       if (se.scenarios != null) {
          params = params.set("scenarios", JSON.stringify(se.scenarios))

--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -297,8 +297,8 @@ export class NewScheduledEventComponent implements OnInit {
         'event_name': this.se.event_name,
         'description': this.se.description,
         'access_code': this.se.access_code,
-        'restricted_bind': true,
-        'on_demand': true,
+        'restricted_bind': !this.se.disable_restriction,  // opposite, since restricted_bind: enabled really means disable_restriction: false
+        'on_demand': this.se.on_demand,
       });
 
       // auto-select the environments


### PR DESCRIPTION
Restricted Bind and On Demand options could not be updated.
Also they were always displayed as true in the UI when updating.

This PR adds some features so that these options will
1. display the correct state
2. be updated (At least when there are corresponding additions to gargantua) 