### PR TITLE
Better calculation for required VMs

### DIFF
--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -280,15 +280,26 @@ export class NewScheduledEventComponent implements OnInit {
     }
     })
     this.selectedcourses.forEach((sc, i) => { // sc is selected course, i is index
+      let vmCountPerTemplate = {}
       sc.virtualmachines.forEach((vmset, j) => { // vmset is virtualmachineset, j is index
+        // 1. sum up count of vms needed for this course.
         Object.values(vmset).forEach((template: string, k) => { // template is vmtemplate name, k is index
-          if (this.requiredVmCounts[template]) {
-            this.requiredVmCounts[template]++;
+          if (vmCountPerTemplate[template]) {
+            vmCountPerTemplate[template]++;
           } else {
-            this.requiredVmCounts[template] = 1;
+            vmCountPerTemplate[template] = 1;
           }
         })
       })
+
+      // 2. Set the required VM count to the maximum count of VMs needed
+      for (let template in vmCountPerTemplate) {
+        if (this.requiredVmCounts[template]) {
+          this.requiredVmCounts[template] = Math.max(vmCountPerTemplate[template], this.requiredVmCounts[template]);
+        } else {
+          this.requiredVmCounts[template] = vmCountPerTemplate[template];
+        }
+      }
     })
   }
 

--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -259,15 +259,25 @@ export class NewScheduledEventComponent implements OnInit {
   public calculateRequiredVms() {
     this.requiredVmCounts = {}; // this will be map[string]int, where string is vm template and int is required count
     this.selectedscenarios.forEach((ss, i) => { // ss is selectedscenario, i is index
+      let vmCountPerTemplate = {} // this will be map[string]int, where string is vm template and int is required count for this scenario.
       ss.virtualmachines.forEach((vmset, j) => { // vmset is virtualmachineset, j is index
+        // 1. sum up count of vms needed for this scenario.
         Object.values(vmset).forEach((template: string, k) => { // tmeplate is vmtemplate name, k is index
-          if (this.requiredVmCounts[template]) {
-            this.requiredVmCounts[template]++;
+          if (vmCountPerTemplate[template]) {
+            vmCountPerTemplate[template]++;
           } else {
-            this.requiredVmCounts[template] = 1;
+            vmCountPerTemplate[template] = 1;
           }
         })
       })
+      // 2. Set the required VM count to the maximum count of VMs needed in one scenario.
+      for (let template in vmCountPerTemplate) {
+        if (this.requiredVmCounts[template]) {
+          this.requiredVmCounts[template] = Math.max(vmCountPerTemplate[template], this.requiredVmCounts[template]);
+        } else {
+          this.requiredVmCounts[template] = vmCountPerTemplate[template];
+        }
+    }
     })
     this.selectedcourses.forEach((sc, i) => { // sc is selected course, i is index
       sc.virtualmachines.forEach((vmset, j) => { // vmset is virtualmachineset, j is index


### PR DESCRIPTION
This PR changes the way required VMs are calculated.
Before this change the number VMs required was calculated by simply adding up the VMs required by each scenario selected in a SE.

However a user can not start 2 scenarios at the same time thus creating overhead VMs when static provisioning VMs.
This PR changes the calculation, taking the highest count of VMs needed per template instead of just adding them up.

Example:
1st scenario needs 3x VM A
2nd scenario also needs 2x VM A and 1x VM B

Before this PR there were 6 VMs created: 5x A, 1x B
With this PR a count of 4 Vms is calculated: 3x A, 1x B as this is the maximum needed.

