### PR TITLE
Change ScheduledeventService to cache SEs and make changes observable

### DIFF
--- a/src/app/event/event.component.ts
+++ b/src/app/event/event.component.ts
@@ -35,7 +35,11 @@ export class EventComponent implements OnInit {
   @ViewChild("deletemodal", { static: true }) deletemodal: ClrModal;
 
   ngOnInit() {
-    this.refresh();
+    this.seService.list().subscribe(
+      (se: ScheduledEvent[]) => {
+        this.events = se;
+      }
+    );
   }
 
   public openDelete(se: ScheduledEvent) {
@@ -76,12 +80,11 @@ export class EventComponent implements OnInit {
   }
 
   public refresh() {
-    this.seService.list()
-      .subscribe(
-        (se: ScheduledEvent[]) => {
-          this.events = se;
-        }
-      )
+    this.seService.list(true).subscribe(
+      (se: ScheduledEvent[]) => {
+        this.events = se;
+      }
+    );
   }
 
   public newupdated() {

--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -357,10 +357,16 @@ export class NewScheduledEventComponent implements OnInit {
       .subscribe(
         (c: Course[]) => { this.courses = c },
       );
-    this.ses.list()
-      .subscribe(
-        (se: ScheduledEvent[]) => { this.scheduledEvents = se },
-      );
+    this.ses.watch().subscribe(
+      (se: ScheduledEvent[]) => {
+        this.scheduledEvents = se;
+      }
+    );
+    this.ses.list().subscribe(
+      (se: ScheduledEvent[]) => {
+        this.scheduledEvents = se;
+      }
+    );
 
     // setup the times
     ["00", "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"].forEach(


### PR DESCRIPTION
This PR fixes https://github.com/hobbyfarm/hobbyfarm/issues/157

ScheduledeventService will now cache the Scheduledevents and can be observed for changes.
This was required by the bug described in https://github.com/hobbyfarm/hobbyfarm/issues/157 where the list of scheduledevents was out of date when deleting or creating a new event, thus allowing for duplicate access codes or marking access codes as duplicate when they are in fact not.

(This also saves one request every time the scheduledevent view is loaded)