### PR TITLE
Only display relevant VM templates

### DIFF
--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -166,14 +166,16 @@ export class NewScheduledEventComponent implements OnInit {
 
   public setupAdvancedVMPage(ea: EnvironmentAvailability) {
     var newFormGroup = new FormGroup({});
-    this.getTemplates(ea.environment).forEach((templateName: string, index: number) => {
-      var initVal = 0;
-      if (this.se.required_vms[ea.environment]) {
-        initVal = this.se.required_vms[ea.environment][templateName] || 0; // so we don't blow away old input values when rebuilding this form
+    let templates = this.getTemplates(ea.environment)
+    for (let template in this.requiredVmCounts){
+      if(!templates.includes(template)){
+        //this environment does not support this template
+        continue;
       }
-      var newControl = new FormControl(initVal, [Validators.pattern(/-?\d+/), Validators.max(ea.available_count[templateName])]);
-      newFormGroup.addControl(templateName, newControl);
-    });
+      var initVal = this.se.required_vms[ea.environment]?.[template] ?? 0; // so we don't blow away old input values when rebuilding this form
+      var newControl = new FormControl(initVal, [Validators.pattern(/-?\d+/), Validators.max(ea.available_count[template])]);
+      newFormGroup.addControl(template, newControl);
+  }
 
     this.vmCounts.addControl(ea.environment, newFormGroup);
   }


### PR DESCRIPTION
This PR fixes https://github.com/hobbyfarm/hobbyfarm/issues/22

When creating a new SE in "advanced mode" all VM Types are shown, also if we only need some types for the scenarios we have selected before.
This PR changes the way VM types are displayed and only shows us the required templates.