### PR TITLE
Fix admin logo css style

### DIFF
--- a/src/app/login/login.component.scss
+++ b/src/app/login/login.component.scss
@@ -3,7 +3,7 @@
     background-position: 21rem 0;
 }
 
-#rancher-login-logo {
+#login-logo {
     width: 75%;
     height: auto;
 }


### PR DESCRIPTION
The CSS Style for the admin logo was not adjusted and therefore was ignored. When using a large sized image, the image would be displayed at full width.
This fixes the ID in the CSS file