### PR TITLE
Correct the New Event environment availability check to use the object-id vs display name

### DIFF
--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -593,7 +593,7 @@ export class NewScheduledEventComponent implements OnInit {
         }),
         concatMap((e: Environment) => {
           return this.es.available(
-            e.display_name,
+            e.name,
             this.se.start_time,
             this.se.end_time
           );


### PR DESCRIPTION
When checking for Environment availability first you gather the list of environments, then POST an availability request based on start and end timestamps as well as the environment name.

In the New Event environment, the availability check makes a request based on the events display_name vs the name (which is the objectid). This results in a 500 error from gargantua as it cannot find the display_name