### PR TITLE
Fix RBAC Directive for virtualmachinetemplates

### DIFF
--- a/src/app/configuration/configuration.component.html
+++ b/src/app/configuration/configuration.component.html
@@ -5,7 +5,7 @@
             <section class="sidenav-content">
                 <a href="javascript://" class="nav-link" [routerLink]="['environments']" [routerLinkActive]="'active'" *rbac="['environments.list']">
                     Environments</a>
-                <a href="javascript://" class="nav-link" [routerLink]="['vmtemplates']" [routerLinkActive]="'active'" *rbac="['vmtemplates.list']">
+                <a href="javascript://" class="nav-link" [routerLink]="['vmtemplates']" [routerLinkActive]="'active'" *rbac="['virtualmachinetemplates.list']">
                     VM Templates</a>
                 <a href="javascript://" class="nav-link" [routerLink]="['roles']" [routerLinkActive]="'active'" *rbac="['roles.list']">
                     Roles</a>


### PR DESCRIPTION
This fixes the RBAC Directive for Virutalmachinetemplates. 
VMTemplates is not an allowed resource