### PR TITLE
Add details component for environments and vm templates

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -55,6 +55,7 @@ import { RuleFormComponent } from './configuration/roles/rule-form/rule-form.com
 import { RolebindingsComponent } from './user/rolebindings/rolebindings.component';
 import { NewRoleBindingComponent } from './user/new-role-binding/new-role-binding.component';
 import { DeleteProcessModalComponent } from './user/user/delete-process-modal/delete-process-modal.component';
+import { EnvironmentDetailComponent } from './configuration/environments/environment-detail/environment-detail.component';
 
 const appInitializerFn = (appConfig: AppConfigService) => {
   return () => {
@@ -117,6 +118,7 @@ export function jwtOptionsFactory() {
     RuleFormComponent,
     RolebindingsComponent,
     NewRoleBindingComponent,
+    EnvironmentDetailComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { RolebindingsComponent } from './user/rolebindings/rolebindings.componen
 import { NewRoleBindingComponent } from './user/new-role-binding/new-role-binding.component';
 import { DeleteProcessModalComponent } from './user/user/delete-process-modal/delete-process-modal.component';
 import { EnvironmentDetailComponent } from './configuration/environments/environment-detail/environment-detail.component';
+import { VmTemplateDetailComponent } from './configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component';
 
 const appInitializerFn = (appConfig: AppConfigService) => {
   return () => {
@@ -119,6 +120,7 @@ export function jwtOptionsFactory() {
     RolebindingsComponent,
     NewRoleBindingComponent,
     EnvironmentDetailComponent,
+    VmTemplateDetailComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.html
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.html
@@ -1,0 +1,63 @@
+<div [clrLoading]="loading">
+    <clr-stack-view>
+        <clr-stack-block>
+            <clr-stack-label>Basic Information</clr-stack-label>
+            <clr-stack-block>
+                <clr-stack-label class="stackbox-header">Option</clr-stack-label>
+                <clr-stack-content class="stackbox-header">Value</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>DNS Suffix</clr-stack-label>
+                <clr-stack-content>{{ currentEnvironment.dnssuffix }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Websocket Endpoint</clr-stack-label>
+                <clr-stack-content>{{ currentEnvironment.ws_endpoint }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Capacity Mode</clr-stack-label>
+                <clr-stack-content>{{ currentEnvironment.capacity_mode }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Burst Capable</clr-stack-label>
+                <clr-stack-content>{{ currentEnvironment.burst_capable }}</clr-stack-content>
+            </clr-stack-block>
+        </clr-stack-block>
+        <clr-stack-block>
+            <clr-stack-label>Environment Specifics</clr-stack-label>
+            <clr-stack-block>
+                <clr-stack-label class="stackbox-header">Key</clr-stack-label>
+                <clr-stack-content class="stackbox-header">Value</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block *ngFor="let item of currentEnvironment.environment_specifics | keyvalue">
+                <clr-stack-label>{{ item.key }}</clr-stack-label>
+                <clr-stack-content>{{ item.value }}</clr-stack-content>
+            </clr-stack-block>
+        </clr-stack-block>
+        <clr-stack-block>
+            <clr-stack-label>Template Mappings</clr-stack-label>
+            <clr-stack-block *ngFor="let template of currentEnvironment.template_mapping | keyvalue">
+                <clr-stack-label>{{ template.key }}</clr-stack-label>
+                <clr-stack-block>
+                    <clr-stack-label class="stackbox-header">Key</clr-stack-label>
+                    <clr-stack-content class="stackbox-header">Value</clr-stack-content>
+                </clr-stack-block>
+                <clr-stack-block *ngFor="let item of template.value | keyvalue">
+                    <clr-stack-label>{{ item.key }}</clr-stack-label>
+                    <clr-stack-content>{{ item.value }}</clr-stack-content>
+                </clr-stack-block>
+            </clr-stack-block>
+        </clr-stack-block>
+        <clr-stack-block *ngIf="currentEnvironment.ip_translation_map">
+            <clr-stack-label>IP Mappings</clr-stack-label>
+            <clr-stack-block>
+                <clr-stack-label class="stackbox-header">From</clr-stack-label>
+                <clr-stack-content class="stackbox-header">To</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block *ngFor="let item of currentEnvironment.ip_translation_map | keyvalue">
+                <clr-stack-label>{{ item.key }}</clr-stack-label>
+                <clr-stack-content>{{ item.value }}</clr-stack-content>
+            </clr-stack-block>
+        </clr-stack-block>
+    </clr-stack-view>
+</div>

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.html
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.html
@@ -1,5 +1,5 @@
 <div [clrLoading]="loading">
-    <clr-stack-view>
+    <clr-stack-view *ngIf="currentEnvironment; else noContent">
         <clr-stack-block>
             <clr-stack-label>Basic Information</clr-stack-label>
             <clr-stack-block>
@@ -34,9 +34,17 @@
                 <clr-stack-content>{{ item.value }}</clr-stack-content>
             </clr-stack-block>
         </clr-stack-block>
-        <clr-stack-block>
+        <clr-stack-block [(clrSbExpanded)]="templateMappingsExpanded">
             <clr-stack-label>Template Mappings</clr-stack-label>
-            <clr-stack-block *ngFor="let template of currentEnvironment.template_mapping | keyvalue">
+            <clr-stack-content>
+                <button class="btn btn-sm btn-link btn-link-stack" (click)="expandAll($event)">
+                    Expand All
+                </button>
+                <button class="btn btn-sm btn-link btn-link-stack" (click)="collapseAll($event)">
+                    Collapse All
+                </button>
+            </clr-stack-content>
+            <clr-stack-block *ngFor="let template of currentEnvironment.template_mapping | keyvalue; let i = index" [(clrSbExpanded)]="stackBoxExpanded[i]">
                 <clr-stack-label>{{ template.key }}</clr-stack-label>
                 <clr-stack-block>
                     <clr-stack-label class="stackbox-header">Key</clr-stack-label>
@@ -60,4 +68,14 @@
             </clr-stack-block>
         </clr-stack-block>
     </clr-stack-view>
+
+    <ng-template #noContent>
+        <clr-alert [clrAlertType]="'warning'" [clrAlertClosable]="false">
+            <clr-alert-item>
+                <span class="alert-text">
+                    No content available!
+                </span>
+            </clr-alert-item>
+        </clr-alert>
+    </ng-template>
 </div>

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.html
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.html
@@ -56,7 +56,7 @@
                 </clr-stack-block>
             </clr-stack-block>
         </clr-stack-block>
-        <clr-stack-block *ngIf="currentEnvironment.ip_translation_map">
+        <clr-stack-block *ngIf="currentEnvironment.ip_translation_map && !isEmpty(currentEnvironment.ip_translation_map)">
             <clr-stack-label>IP Mappings</clr-stack-label>
             <clr-stack-block>
                 <clr-stack-label class="stackbox-header">From</clr-stack-label>

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.scss
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.scss
@@ -1,0 +1,3 @@
+.stackbox-header {
+    font-weight: bold;
+}

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.scss
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.scss
@@ -1,3 +1,11 @@
 .stackbox-header {
     font-weight: bold;
 }
+
+::ng-deep .stack-view .stack-children .stack-block-content {
+    background-color: inherit;
+}
+
+::ng-deep .stack-view .stack-view-key {
+    align-self: center;
+}

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.ts
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.ts
@@ -11,6 +11,8 @@ export class EnvironmentDetailComponent implements OnInit {
   @Input() id: string;
 
   public loading: boolean;
+  public stackBoxExpanded: boolean[] = [];
+  public templateMappingsExpanded: boolean = false;
   public currentEnvironment: Environment;
 
   constructor(public environmentService: EnvironmentService) {}
@@ -19,8 +21,31 @@ export class EnvironmentDetailComponent implements OnInit {
     this.loading = true;
     // Make the server call
     this.environmentService.get(this.id).subscribe((e: Environment) => {
+      // initialize two-way binding variables for stack block state
+      const templateMappingsCount: number = Object.keys(e.template_mapping).length;
+      for(let i = 0; i < templateMappingsCount; ++i) {
+        this.stackBoxExpanded.push(false);
+      }
+
       this.currentEnvironment = e;
       this.loading = false;
     });
   }
+
+  expandAll(event: Event) {
+    event.stopPropagation();
+    this.templateMappingsExpanded = true;
+    for(let i = 0; i < this.stackBoxExpanded.length; ++i) {
+      this.stackBoxExpanded[i] = true;
+    }
+  }
+
+  collapseAll(event: Event) {
+    event.stopPropagation();
+    this.templateMappingsExpanded = false;
+    for(let i = 0; i < this.stackBoxExpanded.length; ++i) {
+      this.stackBoxExpanded[i] = false;
+    }
+  }
+
 }

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.ts
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.ts
@@ -48,4 +48,7 @@ export class EnvironmentDetailComponent implements OnInit {
     }
   }
 
+  isEmpty(object: Object) {
+    return Object.keys(object).length == 0;
+  }
 }

--- a/src/app/configuration/environments/environment-detail/environment-detail.component.ts
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Environment } from 'src/app/data/environment';
+import { EnvironmentService } from 'src/app/data/environment.service';
+
+@Component({
+  selector: 'environment-detail',
+  templateUrl: './environment-detail.component.html',
+  styleUrls: ['./environment-detail.component.scss']
+})
+export class EnvironmentDetailComponent implements OnInit {
+  @Input() id: string;
+
+  public loading: boolean;
+  public currentEnvironment: Environment;
+
+  constructor(public environmentService: EnvironmentService) {}
+
+  ngOnInit() {
+    this.loading = true;
+    // Make the server call
+    this.environmentService.get(this.id).subscribe((e: Environment) => {
+      this.currentEnvironment = e;
+      this.loading = false;
+    });
+  }
+}

--- a/src/app/configuration/environments/environments.component.html
+++ b/src/app/configuration/environments/environments.component.html
@@ -18,13 +18,16 @@
             <clr-dg-column>Object Id</clr-dg-column>
 
             <clr-dg-row *clrDgItems="let e of environments; let i = index">
-                <clr-dg-action-overflow *rbac="['environments.update', 'environments.delete']; op 'OR'">
-                    <button class="action-item" (click)="openUpdate(i)" *rbac="['environments.update']">Edit</button>
+                <clr-dg-action-overflow *ngIf="showActionOverflow">
+                    <button class="action-item" (click)="openUpdate(i)" *rbac="['environments.get', 'environments.update']; op 'AND'">Edit</button>
                     <button class="action-item" disabled *rbac="['environments.delete']">Delete</button>
                 </clr-dg-action-overflow>
                 <clr-dg-cell>{{ e.display_name }}</clr-dg-cell>
                 <clr-dg-cell>{{ e.provider }}</clr-dg-cell>
                 <clr-dg-cell>{{ e.name }}</clr-dg-cell>
+                <ng-container ngProjectAs="clr-dg-row-detail" *rbac="['environments.get']">
+                    <environment-detail *clrIfExpanded [id]="e.name" ngProjectAs="clr-dg-row-detail"></environment-detail>
+                </ng-container>
             </clr-dg-row>
         </clr-datagrid>
     </div>

--- a/src/app/configuration/environments/environments.component.ts
+++ b/src/app/configuration/environments/environments.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewChild } from '@angular/core';
 import { EnvironmentService } from 'src/app/data/environment.service';
 import { Environment } from 'src/app/data/environment';
 import { EditEnvironmentComponent } from './edit-environment/edit-environment.component';
+import { RbacService } from 'src/app/data/rbac.service';
 
 @Component({
   selector: 'app-environments',
@@ -10,14 +11,21 @@ import { EditEnvironmentComponent } from './edit-environment/edit-environment.co
 export class EnvironmentsComponent implements OnInit {
   public environments: Environment[] = [];
   public updateEnv: Environment;
+  public showActionOverflow: boolean = false;
 
   constructor(
-    public environmentService: EnvironmentService
+    public environmentService: EnvironmentService,
+    public rbacService: RbacService
   ) { }
 
   @ViewChild("editEnvironmentWizard", {static: true}) editWizard: EditEnvironmentComponent;
 
   ngOnInit() {
+    this.rbacService.Grants("environments", "get").then(async (allowGet: boolean) => {
+      const allowUpdate: boolean = await this.rbacService.Grants("environments", "update");
+      const allowDelete: boolean = await this.rbacService.Grants("environments", "delete");
+      this.showActionOverflow = allowDelete || (allowGet && allowUpdate);
+    });
     this.refresh();
   }
 
@@ -36,6 +44,10 @@ export class EnvironmentsComponent implements OnInit {
 
   public openUpdate(index: number) {
     this.updateEnv = this.environments[index];
-    this.editWizard.open();
+    // this is only a partial environment, we need to get the full
+    this.environmentService.get(this.environments[index].name).subscribe((e: Environment) => {
+      this.updateEnv = e;
+      this.editWizard.open();
+    });
   }
 }

--- a/src/app/configuration/environments/environments.component.ts
+++ b/src/app/configuration/environments/environments.component.ts
@@ -43,8 +43,7 @@ export class EnvironmentsComponent implements OnInit {
   }
 
   public openUpdate(index: number) {
-    this.updateEnv = this.environments[index];
-    // this is only a partial environment, we need to get the full
+    // "this.environments[index]"" is only a partial environment, we need to get the full
     this.environmentService.get(this.environments[index].name).subscribe((e: Environment) => {
       this.updateEnv = e;
       this.editWizard.open();

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.html
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.html
@@ -81,7 +81,7 @@
                 </ng-container>
             </tbody>
         </table>
-        <ng-container *ngIf="!configMap.valid">
+        <ng-container *ngIf="configMap && !configMap.valid">
             <span class="clr-subtext">All mappings must have key and value filled out. Complete, or remove, any entries that do not.</span>
         </ng-container>
     </clr-wizard-page>

--- a/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.html
+++ b/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.html
@@ -27,7 +27,7 @@
                 <clr-stack-content>{{ currentVmTemplate.resources.storage }}</clr-stack-content>
             </clr-stack-block>
         </clr-stack-block>
-        <clr-stack-block *ngIf="currentVmTemplate.config_map">
+        <clr-stack-block *ngIf="currentVmTemplate.config_map && !isEmpty(currentVmTemplate.config_map)">
             <clr-stack-label>Config Map</clr-stack-label>
             <clr-stack-block>
                 <clr-stack-label class="stackbox-header">Key</clr-stack-label>

--- a/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.html
+++ b/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.html
@@ -1,0 +1,51 @@
+<div [clrLoading]="loading">
+    <clr-stack-view *ngIf="currentVmTemplate; else noContent">
+        <clr-stack-block>
+            <clr-stack-label>Basic Information</clr-stack-label>
+            <clr-stack-block>
+                <clr-stack-label class="stackbox-header">Option</clr-stack-label>
+                <clr-stack-content class="stackbox-header">Value</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Name</clr-stack-label>
+                <clr-stack-content>{{ currentVmTemplate.name }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Image</clr-stack-label>
+                <clr-stack-content>{{ currentVmTemplate.image }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>CPU</clr-stack-label>
+                <clr-stack-content>{{ currentVmTemplate.resources.cpu }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Memory</clr-stack-label>
+                <clr-stack-content>{{ currentVmTemplate.resources.memory }}</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block>
+                <clr-stack-label>Storage</clr-stack-label>
+                <clr-stack-content>{{ currentVmTemplate.resources.storage }}</clr-stack-content>
+            </clr-stack-block>
+        </clr-stack-block>
+        <clr-stack-block *ngIf="currentVmTemplate.config_map">
+            <clr-stack-label>Config Map</clr-stack-label>
+            <clr-stack-block>
+                <clr-stack-label class="stackbox-header">Key</clr-stack-label>
+                <clr-stack-content class="stackbox-header">Value</clr-stack-content>
+            </clr-stack-block>
+            <clr-stack-block *ngFor="let item of currentVmTemplate.config_map | keyvalue">
+                <clr-stack-label>{{ item.key }}</clr-stack-label>
+                <clr-stack-content>{{ item.value }}</clr-stack-content>
+            </clr-stack-block>
+        </clr-stack-block>
+    </clr-stack-view>
+    <ng-template #noContent>
+        <clr-alert [clrAlertType]="'warning'" [clrAlertClosable]="false">
+            <clr-alert-item>
+                <span class="alert-text">
+                    No content available!
+                </span>
+            </clr-alert-item>
+        </clr-alert>
+    </ng-template>
+</div>

--- a/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.scss
+++ b/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.scss
@@ -1,0 +1,3 @@
+.stackbox-header {
+    font-weight: bold;
+}

--- a/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.ts
+++ b/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.ts
@@ -23,4 +23,8 @@ export class VmTemplateDetailComponent implements OnInit {
       this.loading = false;
     });
   }
+
+  isEmpty(object: Object) {
+    return Object.keys(object).length == 0;
+  }
 }

--- a/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.ts
+++ b/src/app/configuration/vmtemplates/vmtemplate-detail/vmtemplate-detail.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { VMTemplate } from 'src/app/data/vmtemplate';
+import { VmtemplateService } from 'src/app/data/vmtemplate.service';
+
+@Component({
+  selector: 'vmtemplate-detail',
+  templateUrl: './vmtemplate-detail.component.html',
+  styleUrls: ['./vmtemplate-detail.component.scss']
+})
+export class VmTemplateDetailComponent implements OnInit {
+  @Input() id: string;
+
+  public loading: boolean;
+  public currentVmTemplate: VMTemplate;
+
+  constructor(public vmTemplateService: VmtemplateService) {}
+
+  ngOnInit() {
+    this.loading = true;
+    // Make the server call
+    this.vmTemplateService.get(this.id).subscribe((t: VMTemplate) => {
+      this.currentVmTemplate = t;
+      this.loading = false;
+    });
+  }
+}

--- a/src/app/configuration/vmtemplates/vmtemplates.component.html
+++ b/src/app/configuration/vmtemplates/vmtemplates.component.html
@@ -19,13 +19,16 @@
             <clr-dg-column [clrDgField]="'id'">Object Id</clr-dg-column>
 
             <clr-dg-row *clrDgItems="let t of templates; let i = index">
-                <clr-dg-action-overflow *rbac="['virtualmachinetemplates.update', 'virtualmachinetemplates.delete']; op 'OR'">
-                    <button class="action-item" (click)="openEdit(t)" *rbac="['virtualmachinetemplates.update']">Edit</button>
+                <clr-dg-action-overflow *ngIf="showActionOverflow">
+                    <button class="action-item" (click)="openEdit(t)" *rbac="['virtualmachinetemplates.get', 'virtualmachinetemplates.update']; op 'AND'">Edit</button>
                     <button class="action-item" (click)="openDelete(t)" *rbac="['virtualmachinetemplates.delete']">Delete</button>
                 </clr-dg-action-overflow>
                 <clr-dg-cell>{{ t.name }}</clr-dg-cell>
                 <clr-dg-cell>{{ t.image }}</clr-dg-cell>
                 <clr-dg-cell>{{ t.id }}</clr-dg-cell>
+                <ng-container ngProjectAs="clr-dg-row-detail" *rbac="['virtualmachinetemplates.get']">
+                    <vmtemplate-detail *clrIfExpanded [id]="t.name" ngProjectAs="clr-dg-row-detail"></vmtemplate-detail>
+                </ng-container>
             </clr-dg-row>
         </clr-datagrid>
     </div>

--- a/src/app/configuration/vmtemplates/vmtemplates.component.html
+++ b/src/app/configuration/vmtemplates/vmtemplates.component.html
@@ -6,7 +6,7 @@
 </div>
 <div class="clr-row">
     <div class="clr-col">
-        <button class="btn btn-success" (click)="openNew()" *rbac="['vmtemplates.create']">
+        <button class="btn btn-success" (click)="openNew()" *rbac="['virtualmachinetemplates.create']">
             <clr-icon shape="plus"></clr-icon> New
         </button>
     </div>
@@ -19,9 +19,9 @@
             <clr-dg-column [clrDgField]="'id'">Object Id</clr-dg-column>
 
             <clr-dg-row *clrDgItems="let t of templates; let i = index">
-                <clr-dg-action-overflow *rbac="['vmtemplates.update', 'vmtemplates.delete']; op 'OR'">
-                    <button class="action-item" (click)="openEdit(t)" *rbac="['vmtemplates.update']">Edit</button>
-                    <button class="action-item" (click)="openDelete(t)" *rbac="['vmtemplates.delete']">Delete</button>
+                <clr-dg-action-overflow *rbac="['virtualmachinetemplates.update', 'virtualmachinetemplates.delete']; op 'OR'">
+                    <button class="action-item" (click)="openEdit(t)" *rbac="['virtualmachinetemplates.update']">Edit</button>
+                    <button class="action-item" (click)="openDelete(t)" *rbac="['virtualmachinetemplates.delete']">Delete</button>
                 </clr-dg-action-overflow>
                 <clr-dg-cell>{{ t.name }}</clr-dg-cell>
                 <clr-dg-cell>{{ t.image }}</clr-dg-cell>

--- a/src/app/data/environment.service.ts
+++ b/src/app/data/environment.service.ts
@@ -17,6 +17,13 @@ export class EnvironmentService {
     public http: HttpClient
   ) { }
 
+  public get(id: string) {
+    return this.http.get(environment.server + "/a/environment/" + id)
+      .pipe(
+        map((s: ServerResponse) => JSON.parse(atou(s.content)))
+      )
+  }
+
   public list() {
     return this.http.get(environment.server + "/a/environment/list")
     .pipe(

--- a/src/app/vmset/vmset.component.html
+++ b/src/app/vmset/vmset.component.html
@@ -15,15 +15,15 @@
                     (click)="deleteVM(i, item.key)" *ngIf="updateRbac">Delete
                     VM</button></clr-stack-content>
         </clr-stack-block>
-        <clr-stack-block>
-            <clr-stack-label><button class="btn btn-sm btn-link btn-link-stack" (click)="openAddVm(i)" disabled="!allowedAddVm" *ngIf="updateRbac">New
+        <clr-stack-block *ngIf="updateRbac">
+            <clr-stack-label><button class="btn btn-sm btn-link btn-link-stack" (click)="openAddVm(i)" disabled="!allowedAddVm">New
                     VM</button>
             </clr-stack-label>
-            <clr-stack-content *ngIf="updateRbac && !allowedAddVm">
-                <clr-alert [clrAlertType]="'warning'" [clrAlertSizeSmall]="true" [clrAlertClosable]="false">
+            <clr-stack-content *ngIf="!allowedAddVm">
+                <clr-alert [clrAlertType]="'info'" [clrAlertSizeSmall]="true" [clrAlertClosable]="false">
                     <clr-alert-item>
                       <span class="alert-text">
-                        No permission to list VM templates!
+                        Permission virtualmachinetemplates.LIST required to add VMs
                       </span>
                     </clr-alert-item>
                   </clr-alert>


### PR DESCRIPTION
**What this PR does / why we need it**:
- Implements detail component for environments and vm templates if the user owns the corresponding GET permission
- Works with https://github.com/hobbyfarm/gargantua/pull/114

**Which issue(s) this PR fixes**: fixes [hobbyfarm/hobbyfarm#213](https://github.com/hobbyfarm/hobbyfarm/issues/213)