### PR TITLE
Css and fixes

### DIFF
--- a/src/app/configuration/environments/environment-detail/environment-detail.component.scss
+++ b/src/app/configuration/environments/environment-detail/environment-detail.component.scss
@@ -2,10 +2,10 @@
     font-weight: bold;
 }
 
-::ng-deep .stack-view .stack-children .stack-block-content {
+:host ::ng-deep .stack-view .stack-children .stack-block-content {
     background-color: inherit;
 }
 
-::ng-deep .stack-view .stack-view-key {
+:host ::ng-deep .stack-view .stack-view-key {
     align-self: center;
 }

--- a/src/app/dashboards/vm-dashboard/vm-dashboard.component.ts
+++ b/src/app/dashboards/vm-dashboard/vm-dashboard.component.ts
@@ -42,7 +42,7 @@ export class VmDashboardComponent implements OnInit {
   public vmSets: dashboardVmSet[] = [];
   public emptyVMset: dashboardVmSet = {
     ...new VmSet(),
-    base_name: "Dynmaic",
+    base_name: "Dynamic",
     stepOpen: false
   }
   public selectedVM: VirtualMachine = new VirtualMachine();

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -75,3 +75,14 @@ clr-stack-view.compact {
 clr-datagrid.clr_disable_selection div.datagrid-row-master > div:first-child  {
     display: none;
 }
+
+.modal-body-wrapper {
+    width: 100%;
+    margin-bottom: auto;
+}
+
+/* added because the modal-body is improperly rendering at 70vh,
+overflows the modal and hence displays an unneeded scrollbar */
+.modal-body {
+    min-height: unset !important;
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- `::ng-deep` promotes component styles to global styles (https://angular.io/guide/component-styles). Prevent this effect by using `:host`
- fix typo
- improve rendering of modals