### PR TITLE
Syntax highlighhting for cloud config

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -84,6 +84,7 @@ import { VmTemplateDetailComponent } from './configuration/vmtemplates/vmtemplat
 import { VMTemplateServiceFormComponent } from './configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component';
 import { FilterScenariosComponent } from './filter-scenarios/filter-scenarios.component';
 import { MDEditorComponent } from './scenario/md-editor/md-editor.component';
+import { CodeWithSyntaxHighlightingComponent } from './configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component';
 
 const appInitializerFn = (appConfig: AppConfigService) => {
   return () => {
@@ -155,7 +156,8 @@ export function jwtOptionsFactory() {
     VmTemplateDetailComponent,
     MDEditorComponent,
     VMTemplateServiceFormComponent,
-    FilterScenariosComponent
+    FilterScenariosComponent,
+    CodeWithSyntaxHighlightingComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.html
+++ b/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.html
@@ -1,0 +1,5 @@
+<div class="code-editor">
+    <textarea (input)="onValueChange($event)" [(ngModel)]="textValue">
+    </textarea>
+    <code id="code" class="language-yaml" [innerHTML]="highlightedText"></code>
+</div>

--- a/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.scss
+++ b/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.scss
@@ -1,0 +1,49 @@
+.code-editor {
+    display: block;
+    position: relative;
+    font-family: monospace;
+    line-height: 1.5;
+    width: 500px;
+    height: 500px;
+    border: solid 1px;
+    background-color: #f5f2f0;
+}
+
+.code-editor textarea {
+    z-index: 2;
+    position: absolute;
+    white-space: pre-wrap;
+    background-color: transparent;
+    color: transparent;
+    caret-color: black;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    margin: 0;
+    font-size: inherit;
+    font-family: inherit;
+    line-height: inherit;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.code-editor code {   
+    z-index: 1;
+    pointer-events: none;
+    white-space: pre-wrap;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    margin: 0;
+    font-size: inherit;
+    font-family: inherit;
+    line-height: inherit;
+    background-color: transparent;
+    border: none;
+}

--- a/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.scss
+++ b/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.scss
@@ -25,8 +25,6 @@
     font-size: inherit;
     font-family: inherit;
     line-height: inherit;
-    width: 100%;
-    height: 100%;
     border: none;
 }
 

--- a/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.spec.ts
+++ b/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CodeWithSyntaxHighlightingComponent } from './code-with-syntax-highlighting.component';
+
+describe('CodeWithSyntaxHighlightingComponent', () => {
+  let component: CodeWithSyntaxHighlightingComponent;
+  let fixture: ComponentFixture<CodeWithSyntaxHighlightingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CodeWithSyntaxHighlightingComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CodeWithSyntaxHighlightingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.ts
+++ b/src/app/configuration/code-with-syntax-highlighting/code-with-syntax-highlighting.component.ts
@@ -1,0 +1,41 @@
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output, SimpleChange, SimpleChanges } from '@angular/core';
+import 'prismjs'
+import 'prismjs/components/prism-yaml'
+import { of } from 'rxjs';
+import { connectableObservableDescriptor } from 'rxjs/internal/observable/ConnectableObservable';
+
+declare var Prism: any;
+
+@Component({
+  selector: 'app-code-with-syntax-highlighting',
+  templateUrl: './code-with-syntax-highlighting.component.html',
+  styleUrls: ['./code-with-syntax-highlighting.component.scss']
+})
+export class CodeWithSyntaxHighlightingComponent implements AfterViewInit {
+
+  @Input()
+  textValue: string;
+
+  @Output()
+  textChanged: EventEmitter<string> = new EventEmitter<string>()
+
+  public highlightedText: string;
+
+  ngAfterViewInit() {
+    this.setHighlightedText(this.textValue)
+  }
+
+  setHighlightedText(textValue) {
+    this.highlightedText = Prism.highlight(textValue, Prism.languages.yaml, 'yaml')
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.textValue = changes.textValue.currentValue
+    this.setHighlightedText(changes.textValue.currentValue)
+  }
+
+  onValueChange(event) {
+    let newText: string = event.target.value
+    this.textChanged.emit(newText)
+  }
+}

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.html
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.html
@@ -82,11 +82,12 @@
             </clr-signpost-content>
         </clr-signpost>
         <div [formGroup]="configMap">            
-            <form clrForm style="width: 100%;">
-                <div style="background-color: var(--clr-thead-bgcolor, #fafafa); width: fit-content;padding: 9px; border: 1px solid var(--clr-table-border-color, #cccccc);">
-                    <code class="clr-code" style="white-space: pre; color: var(--clr-table-font-color, #666666);">{{ cloudConfig.cloudConfigYaml }}</code>
+            <form clrForm>
+                <div class="code-container" *ngIf="cloudConfig.cloudConfigYaml.length > 0">
+                    <code class="clr-code">{{ cloudConfig.cloudConfigYaml }}</code>
                 </div>
             </form>
+            <div *ngIf="!cloudConfig.cloudConfigYaml.length">There is no Cloud-Init Configuration defined for this VM-Template. This can be done in the Services Step.</div>
         </div>
         <ng-container *ngIf="configMap && !configMap.valid">
             <span class="clr-subtext">All mappings must have key and value filled out. Complete, or remove, any entries

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.html
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.html
@@ -83,8 +83,8 @@
         </clr-signpost>
         <div [formGroup]="configMap">            
             <form clrForm>
-                <div class="code-container" *ngIf="cloudConfig.cloudConfigYaml.length > 0">
-                    <code class="clr-code">{{ cloudConfig.cloudConfigYaml }}</code>
+                <div *ngIf="cloudConfig.cloudConfigYaml.length > 0">                    
+                    <markdown [data]="cloudConfig.cloudConfigYaml | language: 'yaml'"></markdown>
                 </div>
             </form>
             <div *ngIf="!cloudConfig.cloudConfigYaml.length">There is no Cloud-Init Configuration defined for this VM-Template. This can be done in the Services Step.</div>

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.scss
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.scss
@@ -1,0 +1,11 @@
+.clr-code {
+    white-space: pre; 
+    color: var(--clr-table-font-color, #666666);
+}
+
+.code-container {
+    background-color: var(--clr-thead-bgcolor, #fafafa); 
+    width: 100%;    
+    padding: 9px; 
+    border: 1px solid var(--clr-table-border-color, #cccccc);
+}

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.scss
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.scss
@@ -2,10 +2,3 @@
     white-space: pre; 
     color: var(--clr-table-font-color, #666666);
 }
-
-.code-container {
-    background-color: var(--clr-thead-bgcolor, #fafafa); 
-    width: 100%;    
-    padding: 9px; 
-    border: 1px solid var(--clr-table-border-color, #cccccc);
-}

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.ts
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/edit-vmtemplate.component.ts
@@ -12,6 +12,7 @@ import { VmtemplateService } from 'src/app/data/vmtemplate.service';
 @Component({
   selector: 'edit-vmtemplate-wizard',
   templateUrl: './edit-vmtemplate.component.html',
+  styleUrls: ['./edit-vmtemplate.component.scss']
 })
 export class EditVmtemplateComponent implements OnInit, OnChanges {
   public templateDetails: FormGroup;

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component.html
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component.html
@@ -1,7 +1,4 @@
-<button
-  class="btn btn-table btn-link"
-  (click)="selectVMServiceModalOpen = true"
->
+<button class="btn btn-table btn-link" (click)="selectVMServiceModalOpen = true">
   <clr-icon shape="plus"></clr-icon> Add predefined Service
 </button>
 <button class="btn btn-table btn-link" (click)="openNewVMServiceModal()">
@@ -19,18 +16,12 @@
       <td>{{ interface.value.port }}</td>
       <td>{{ interface.value.hasOwnTab }}</td>
       <td>
-        <button
-          class="btn btn-table btn-link"
-          (click)="editVMServiceClicked(interface.value)"
-        >
+        <button class="btn btn-table btn-link" (click)="editVMServiceClicked(interface.value)">
           EDIT
         </button>
       </td>
       <td>
-        <button
-          class="btn btn-table btn-link"
-          (click)="cloudConfig.removeVMService(interface.key)"
-        >
+        <button class="btn btn-table btn-link" (click)="cloudConfig.removeVMService(interface.key)">
           DELETE
         </button>
       </td>
@@ -42,20 +33,13 @@
   <h3 class="modal-title">Choose a Service</h3>
   <div class="modal-body">
     <select clrSelect [(ngModel)]="selectedNewInterface">
-      <option
-        *ngFor="let interface of predefinedInterfaces"
-        [ngValue]="interface"
-      >
+      <option *ngFor="let interface of predefinedInterfaces" [ngValue]="interface">
         {{ interface.name }}
       </option>
     </select>
   </div>
   <div class="modal-footer">
-    <button
-      type="button"
-      class="btn btn-outline"
-      (click)="selectVMServiceModalOpen = false"
-    >
+    <button type="button" class="btn btn-outline" (click)="selectVMServiceModalOpen = false">
       Cancel
     </button>
     <button type="button" class="btn btn-primary" (click)="selectModalClose()">
@@ -70,75 +54,37 @@
     <form clrForm [formGroup]="newVMServiceFormGroup">
       <clr-input-container>
         <label>Name</label>
-        <input
-          clrInput
-          placeholder="Webserver"
-          name="name"
-          formControlName="name"
-        />
+        <input clrInput placeholder="Webserver" name="name" formControlName="name" />
       </clr-input-container>
       <clr-checkbox-container>
         <clr-checkbox-wrapper>
-          <input
-            type="checkbox"
-            clrCheckbox
-            value="hasWebinterface"
-            name="hasWebinterface"
-            formControlName="hasWebinterface"
-            required
-          />
+          <input type="checkbox" clrCheckbox value="hasWebinterface" name="hasWebinterface"
+            formControlName="hasWebinterface" required />
           <label>Has a Webinterface</label>
         </clr-checkbox-wrapper>
       </clr-checkbox-container>
       <ng-container *ngIf="newVMServiceFormGroup.value['hasWebinterface']">
         <clr-checkbox-container>
           <clr-checkbox-wrapper>
-            <input
-              type="checkbox"
-              clrCheckbox
-              value="hasOwnTab"
-              name="hasOwnTab"
-              formControlName="hasOwnTab"
-            />
+            <input type="checkbox" clrCheckbox value="hasOwnTab" name="hasOwnTab" formControlName="hasOwnTab" />
             <label>Has it's own Tab in the UI</label>
           </clr-checkbox-wrapper>
         </clr-checkbox-container>
         <clr-input-container>
           <label>Port</label>
-          <input
-            type="number"
-            clrInput
-            placeholder="80"
-            name="input"
-            formControlName="port"
-          />
+          <input type="number" clrInput placeholder="80" name="input" formControlName="port" />
         </clr-input-container>
         <clr-input-container>
           <label>Path</label>
-          <input
-            type="text"
-            clrInput
-            placeholder="/dashboard"
-            name="input"
-            formControlName="path"
-          />
+          <input type="text" clrInput placeholder="/dashboard" name="input" formControlName="path" />
         </clr-input-container>
       </ng-container>
-      <textarea
-        clrTextarea
-        style="width: 100%; height: 30vh; padding: 0"
-        name="cloudConfigString"
-        formControlName="cloudConfigString"
-        required
-      ></textarea>
+      <app-code-with-syntax-highlighting [textValue]="newVMServiceFormGroup.value['cloudConfigString']"
+        (textChanged)="newVMServiceFormGroup.controls.cloudConfigString.setValue($event)"></app-code-with-syntax-highlighting>
     </form>
   </div>
   <div class="modal-footer">
-    <button
-      type="button"
-      class="btn btn-outline"
-      (click)="newVMServiceModalOpen = false"
-    >
+    <button type="button" class="btn btn-outline" (click)="newVMServiceModalOpen = false">
       Cancel
     </button>
     <button type="button" class="btn btn-primary" (click)="newVMServiceClose()">


### PR DESCRIPTION
Adds syntax Highlighting via Prism for the Clud-Init-Config Editor in Edit VM-Templates.
Corresponding Issue: [283](https://github.com/hobbyfarm/hobbyfarm/issues/283)