### PR TITLE
Add openssl-legaxy-provider flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Build
         run: npm run build:prod
+        with:
+          NODE_OPTIONS: '--openssl-legacy-provider'
 
       # TODO: lint, sonar, tests
 


### PR DESCRIPTION
Node throws error while building due to openssl being used. Provide the flag to let the build pass