### PR TITLE
Chart update

### DIFF
--- a/src/app/session-statistics/session-statistics.component.html
+++ b/src/app/session-statistics/session-statistics.component.html
@@ -1,11 +1,40 @@
 <div class="main-container" *rbac="['progresses.list']">
   <h3>Session Statistics For Active Events</h3>
   <form [formGroup]="chartDetails" [class.clr-error]="chartDetails.errors?.endDateLowerThanStartDate">
-    <select clrSelect formControlName="observationPeriod" >
-      <option value="daily">Daily</option>
-      <option value="weekly">Weekly</option>
-      <option value="monthly">Monthly</option>
-    </select>
+    <div class="clr-row">
+      <div class="clr-col-lg-4 clr-col-md-4 clr-col-12">
+        <clr-select-container>
+          <label>Observation Period</label>
+          <select clrSelect formControlName="observationPeriod" >
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+        </clr-select-container>
+      </div>
+      <div class="clr-col-lg-4 clr-col-md-4 clr-col-12">
+        <clr-combobox-container>
+          <label>Scenarios</label>
+          <clr-combobox formControlName="scenarios" name="scenarios" clrMulti="true">
+            <ng-container *clrOptionSelected="let scenarioSelected">
+                {{ scenarioSelected }}
+            </ng-container>
+            <clr-options>
+                <clr-option *clrOptionItems="let scenario of scenariosWithSession" [clrValue]="scenario">
+                    <clr-icon shape="node-group"></clr-icon> {{ scenario }}
+                </clr-option>
+            </clr-options>
+          </clr-combobox>
+          <clr-control-error>Scenarios are required.</clr-control-error>
+          <clr-control-helper>
+            <div class="scenario-actions">
+              <a class="scenario-action" href="javascript://" (click)="clearScenarios()">Clear Scenarios</a>
+              <a class="scenario-action" href="javascript://" (click)="addAllScenarios()">Add All Scenarios</a>
+            </div>
+          </clr-control-helper>
+        </clr-combobox-container>
+      </div>
+    </div>
     <div class="clr-row">
       <div class="clr-col-lg-4 clr-col-md-4 clr-col-12">
         <clr-input-container class="date-label-input">

--- a/src/app/session-statistics/session-statistics.component.html
+++ b/src/app/session-statistics/session-statistics.component.html
@@ -56,7 +56,7 @@
         </clr-input-container>
         <clr-signpost class="signpost">
           <button class="btn btn-sm btn-link" clrSignpostTrigger>Change Start Date</button>
-          <clr-signpost-content [clrPosition]="'top-right'" *clrIfOpen #startDateSignpost>
+          <clr-signpost-content [clrPosition]="'right-middle'" *clrIfOpen #startDateSignpost>
             <dl-date-time-picker (change)="setStartDate($event)" [startView]="startView" maxView="year" [minView]="minView">
             </dl-date-time-picker>
           </clr-signpost-content>
@@ -79,7 +79,7 @@
         </clr-input-container>
         <clr-signpost class="signpost">
           <button class="btn btn-link" clrSignpostTrigger>Change End Date</button>
-          <clr-signpost-content [clrPosition]="'top-right'" *clrIfOpen #endDateSignpost>
+          <clr-signpost-content [clrPosition]="'right-middle'" *clrIfOpen #endDateSignpost>
             <dl-date-time-picker (change)="setEndDate($event)" [startView]="startView" maxView="year" [minView]="minView">
             </dl-date-time-picker>
           </clr-signpost-content>

--- a/src/app/session-statistics/session-statistics.component.html
+++ b/src/app/session-statistics/session-statistics.component.html
@@ -107,8 +107,8 @@
     <div class="clr-col-lg-4 clr-col-md-4 clr-col-12">
       <h4>Started Sessions (Overview)</h4>
       <clr-datagrid>
-        <clr-dg-column [clrDgField]="'key'" [clrDgSortOrder]="ascSort">Scenario</clr-dg-column>
-        <clr-dg-column>Total Sessions</clr-dg-column>
+        <clr-dg-column [clrDgField]="'key'">Scenario</clr-dg-column>
+        <clr-dg-column [clrDgSortBy]="'value'" [clrDgSortOrder]="descSort">Total Sessions</clr-dg-column>
         <clr-dg-row *clrDgItems="let item of totalSessionsPerScenario | keyvalue">
           <clr-dg-cell>{{item.key}}</clr-dg-cell>
           <clr-dg-cell>{{item.value}}</clr-dg-cell>

--- a/src/app/session-statistics/session-statistics.component.scss
+++ b/src/app/session-statistics/session-statistics.component.scss
@@ -6,3 +6,13 @@
 .signpost {
   margin-left: -0.6rem;
 }
+
+.scenario-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+.scenario-action {
+  margin-right: 0.6rem;
+}

--- a/src/app/session-statistics/session-statistics.component.ts
+++ b/src/app/session-statistics/session-statistics.component.ts
@@ -90,7 +90,7 @@ export class SessionStatisticsComponent implements OnInit {
   ];
   public scenariosWithSession: string[] = [];
   public totalSessionsPerScenario: Map<string, number> = new Map();
-  public ascSort = ClrDatagridSortOrder.ASC;
+  public descSort = ClrDatagridSortOrder.DESC;
 
   constructor(
     public progressService: ProgressService,


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates https://github.com/hobbyfarm/admin-ui/pull/147.
- scenarios shown in the session statistic chart can now be prefiltered
- scenarios shown in the session statistic data grid are now sorted by number of total sessions
- moved the signposts for updating start/end date back to the default position