### PR TITLE
Fix cloud init not saved

### DIFF
--- a/src/app/data/vmtemplate.service.ts
+++ b/src/app/data/vmtemplate.service.ts
@@ -8,68 +8,70 @@ import { atou } from '../unicode';
 import { VMTemplate } from './vmtemplate';
 import { HttpParameterCodec } from '@angular/common/http';
 
+// Custom Encoder to prevent Angulars default En-/Decoder from decoding special Characters again after encoding them, see https://github.com/angular/angular/blob/875851776c2f1a688554e91b8f5352984a71d16b/packages/common/http/src/params.ts#L94.
+// This behaviour lead to the Data not being saved in Gargantua if it contains ';'.
 export class CustomHttpParamEncoder implements HttpParameterCodec {
-    encodeKey(key: string): string {
-        return encodeURIComponent(key);
-    }
-    encodeValue(value: string): string {
-            return encodeURIComponent(value);
-    }
-    decodeKey(key: string): string {
-            return decodeURIComponent(key);
-    }
-    decodeValue(value: string): string {
-            return decodeURIComponent(value);
-    }
+  encodeKey(key: string): string {
+    return encodeURIComponent(key);
+  }
+  encodeValue(value: string): string {
+    return encodeURIComponent(value);
+  }
+  decodeKey(key: string): string {
+    return decodeURIComponent(key);
+  }
+  decodeValue(value: string): string {
+    return decodeURIComponent(value);
+  }
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class VmtemplateService {
-
-  constructor(
-    public http: HttpClient
-  ) { }
+  constructor(public http: HttpClient) {}
 
   public list() {
-    return this.http.get(environment.server + '/a/vmtemplate/list')
-    .pipe(
+    return this.http.get(environment.server + '/a/vmtemplate/list').pipe(
       switchMap((s: ServerResponse) => {
-        return of(JSON.parse(atou(s.content)))
+        return of(JSON.parse(atou(s.content)));
       })
-    )
+    );
   }
 
   public update(template: VMTemplate) {
-    let params = new HttpParams({encoder: new CustomHttpParamEncoder()})
-    .set('id', template.id)
-    .set('name', template.name)
-    .set('image', template.image)
-    .set('config_map', JSON.stringify(template.config_map))
-   
-    return this.http.put(environment.server + "/a/vmtemplate/" + template.id + "/update", params)
+    let params = new HttpParams({ encoder: new CustomHttpParamEncoder() })
+      .set('id', template.id)
+      .set('name', template.name)
+      .set('image', template.image)
+      .set('config_map', JSON.stringify(template.config_map));
+
+    return this.http.put(
+      environment.server + '/a/vmtemplate/' + template.id + '/update',
+      params
+    );
   }
 
   public create(template: VMTemplate) {
-    let params = new HttpParams()
-    .set('name', template.name)
-    .set('image', template.image)
-    .set('config_map', JSON.stringify(template.config_map))
+    let params = new HttpParams({ encoder: new CustomHttpParamEncoder() })
+      .set('name', template.name)
+      .set('image', template.image)
+      .set('config_map', JSON.stringify(template.config_map));
 
-    return this.http.post(environment.server + "/a/vmtemplate/create", params)
+    return this.http.post(environment.server + '/a/vmtemplate/create', params);
   }
 
   public get(id: string) {
-    return this.http.get(environment.server + "/a/vmtemplate/" + id)
-    .pipe(
+    return this.http.get(environment.server + '/a/vmtemplate/' + id).pipe(
       switchMap((s: ServerResponse) => {
-        return of(JSON.parse(atou(s.content)))
+        return of(JSON.parse(atou(s.content)));
       })
-    )
+    );
   }
 
   public delete(id: string) {
-    return this.http.delete(environment.server + "/a/vmtemplate/" + id + "/delete")
+    return this.http.delete(
+      environment.server + '/a/vmtemplate/' + id + '/delete'
+    );
   }
 }

--- a/src/app/data/vmtemplate.service.ts
+++ b/src/app/data/vmtemplate.service.ts
@@ -6,6 +6,22 @@ import { ServerResponse } from './serverresponse';
 import { of } from 'rxjs';
 import { atou } from '../unicode';
 import { VMTemplate } from './vmtemplate';
+import { HttpParameterCodec } from '@angular/common/http';
+
+export class CustomHttpParamEncoder implements HttpParameterCodec {
+    encodeKey(key: string): string {
+        return encodeURIComponent(key);
+    }
+    encodeValue(value: string): string {
+            return encodeURIComponent(value);
+    }
+    decodeKey(key: string): string {
+            return decodeURIComponent(key);
+    }
+    decodeValue(value: string): string {
+            return decodeURIComponent(value);
+    }
+}
 
 @Injectable({
   providedIn: 'root'
@@ -26,12 +42,12 @@ export class VmtemplateService {
   }
 
   public update(template: VMTemplate) {
-    let params = new HttpParams()
+    let params = new HttpParams({encoder: new CustomHttpParamEncoder()})
     .set('id', template.id)
     .set('name', template.name)
     .set('image', template.image)
     .set('config_map', JSON.stringify(template.config_map))
-
+   
     return this.http.put(environment.server + "/a/vmtemplate/" + template.id + "/update", params)
   }
 


### PR DESCRIPTION
With this PR config maps of VMTemplates containing the character ';' can be saved. This includes cloud init data for Services