### PR TITLE
Fix bug where invalid environments are shown multiple times

### DIFF
--- a/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
+++ b/src/app/event/new-scheduled-event/new-scheduled-event.component.ts
@@ -310,7 +310,9 @@ export class NewScheduledEventComponent implements OnInit {
         ) {
           // this template either doesn't exist in the environment, or doesn't match a minimum count
           meetsCriteria = false;
-          this.invalidSimpleEnvironments.push(ea.environment);
+          if(!this.invalidSimpleEnvironments.includes(ea.environment)){
+            this.invalidSimpleEnvironments.push(ea.environment);
+          }
         }
       }
     );


### PR DESCRIPTION
Sometimes if an environment does not support multiple VMTs, it is shown multiple times in the list of non supported environments