### PR TITLE
Modify OTAC Modal to handle durations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "ng2-dragula": "^2.1.1",
         "ngx-dynamic-hooks": "^1.7.2",
         "ngx-markdown": "^12.1.0",
+        "parse-duration": "^1.1.0",
         "rxjs": "^6.6.7",
         "tslib": "^2.0.0",
         "xterm": "^4.13.0",
@@ -10679,6 +10680,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -24264,6 +24270,11 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "parse-json": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ng2-dragula": "^2.1.1",
     "ngx-dynamic-hooks": "^1.7.2",
     "ngx-markdown": "^12.1.0",
+    "parse-duration": "^1.1.0",
     "rxjs": "^6.6.7",
     "tslib": "^2.0.0",
     "xterm": "^4.13.0",

--- a/src/app/data/otac.type.ts
+++ b/src/app/data/otac.type.ts
@@ -1,5 +1,6 @@
 export type OTAC = {
-    name: string;
-    user?: string;
-    redeemed_timestamp?: string
-}
+  name: string;
+  user?: string;
+  redeemed_timestamp?: string;
+  max_duration?: string;
+};

--- a/src/app/data/scheduledevent.service.ts
+++ b/src/app/data/scheduledevent.service.ts
@@ -133,10 +133,17 @@ export class ScheduledeventService extends ListableResourceClient<ScheduledEvent
       );
   }
 
-  public addOtacs(seId: string, count: number) {
+  public addOtacs(seId: string, count: number, duration: string = '') {
+    var params = new HttpParams().set('max_duration', duration);
+
     return this.http
-      .get(
-        environment.server + '/a/scheduledevent/' + seId + '/otacs/add/' + count
+      .post(
+        environment.server +
+          '/a/scheduledevent/' +
+          seId +
+          '/otacs/add/' +
+          count,
+        params
       )
       .pipe(
         switchMap((s: ServerResponse) => {

--- a/src/app/event/otacmanagement/otacmanagement.component.html
+++ b/src/app/event/otacmanagement/otacmanagement.component.html
@@ -39,7 +39,7 @@
         />
         <clr-control-error
           >Input must be a valid duration consisting of a number followed by
-          (d,h,m). Combinations like "1d20h" are allowed.</clr-control-error
+          (d,h,m).</clr-control-error
         >
       </clr-input-container>
       <button

--- a/src/app/event/otacmanagement/otacmanagement.component.html
+++ b/src/app/event/otacmanagement/otacmanagement.component.html
@@ -1,53 +1,113 @@
-<clr-modal [(clrModalOpen)]="open" [clrModalSize]="'xl'" [clrModalClosable]="false">
-    <h3 class="modal-title" *ngIf="open">
-        OTACs for {{ currentScheduledEvent.event_name }}
-    </h3>
-    <div class="modal-body">
-        <form clrForm [formGroup]="amountInputForm" class="flexbox" *rbac="['scheduledevents.update']">
-            <div>New OTACs:</div>
-            <clr-input-container class="input-container">
-                <input formControlName="amountInput" type="number" clrInput name="amountNewOtacsInput"
-                    [(ngModel)]="amountNewOtacs" />
-                <clr-control-error>Input must be a positive Number</clr-control-error>
-            </clr-input-container>
-            <button [disabled]="!amountInputForm.valid" type="button" class="btn btn-primary" (click)="createOtacs()">
-                generate
+<clr-modal
+  [(clrModalOpen)]="open"
+  [clrModalSize]="'xl'"
+  [clrModalClosable]="false"
+>
+  <h3 class="modal-title" *ngIf="open">
+    OTACs for {{ currentScheduledEvent.event_name }}
+  </h3>
+  <div class="modal-body">
+    <form
+      clrForm
+      [formGroup]="amountInputForm"
+      class="flexbox"
+      *rbac="['scheduledevents.update']"
+    >
+      <div>New OTACs:</div>
+      <clr-input-container class="input-container">
+        <label class="otac-label">Count</label>
+        <input
+          formControlName="amountInput"
+          type="number"
+          clrInput
+          name="amountNewOtacsInput"
+          [(ngModel)]="amountNewOtacs"
+        />
+        <clr-control-error>Input must be a positive Number</clr-control-error>
+      </clr-input-container>
+
+      <clr-input-container class="input-container">
+        <label class="otac-label">Duration</label>
+        <input
+          formControlName="duration"
+          type="text"
+          clrInput
+          name="duration"
+          placeholder="e.g. 1d, 24h, 60m"
+          title="Duration"
+          [(ngModel)]="duration"
+        />
+        <clr-control-error
+          >Input must be a valid duration consisting of a number followed by
+          (d,h,m). Combinations like "1d20h" are allowed.</clr-control-error
+        >
+      </clr-input-container>
+      <button
+        [disabled]="!amountInputForm.valid"
+        type="button"
+        class="btn btn-primary"
+        (click)="createOtacs()"
+      >
+        generate
+      </button>
+    </form>
+
+    <div class="datagrid-container">
+      <clr-datagrid>
+        <clr-dg-column [clrDgField]="'status'" [clrDgSortOrder]="descSort"
+          >Status</clr-dg-column
+        >
+        <clr-dg-column>OTAC</clr-dg-column>
+        <clr-dg-column [clrDgField]="'userEmail'">Claimed by</clr-dg-column>
+        <clr-dg-column>Claimed at</clr-dg-column>
+        <clr-dg-column>Max. Duration</clr-dg-column>
+        <clr-dg-column *rbac="['scheduledevents.update']">Delete</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let otac of otacs">
+          <clr-dg-cell>
+            <span class="badge badge-success" *ngIf="otac.status == 'free'"
+              >free</span
+            >
+            <span class="badge badge-info" *ngIf="otac.status == 'taken'"
+              >taken</span
+            >
+            <span
+              class="badge badge-danger"
+              *ngIf="otac.status == 'out-of-time'"
+              >out-of-time</span
+            >
+          </clr-dg-cell>
+          <clr-dg-cell>{{ otac.name }}</clr-dg-cell>
+          <clr-dg-cell>{{ otac.userEmail }}</clr-dg-cell>
+          <clr-dg-cell>{{ otac.redeemed_timestamp }}</clr-dg-cell>
+          <clr-dg-cell *ngIf="hasMaxDuration(otac)"
+            ><clr-icon shape="clock"></clr-icon>
+            {{ otac.max_duration }}</clr-dg-cell
+          >
+          <clr-dg-cell *ngIf="!hasMaxDuration(otac)"
+            >Until Event ends</clr-dg-cell
+          >
+          <clr-dg-cell *rbac="['scheduledevents.update']">
+            <button
+              type="button"
+              class="btn btn-warning-outline"
+              (click)="deleteOtac(otac)"
+            >
+              Delete
             </button>
-        </form>
+          </clr-dg-cell>
+        </clr-dg-row>
 
-        <div class="datagrid-container">
-            <clr-datagrid>
-                <clr-dg-column [clrDgField]="'status'" [clrDgSortOrder]="descSort">Status</clr-dg-column>
-                <clr-dg-column>OTAC</clr-dg-column>
-                <clr-dg-column [clrDgField]="'userEmail'">Claimed by</clr-dg-column>
-                <clr-dg-column>Claimed at</clr-dg-column>
-                <clr-dg-column *rbac="['scheduledevents.update']">Delete</clr-dg-column>
-
-                <clr-dg-row *clrDgItems="let otac of otacs">
-                    <clr-dg-cell>
-                        <span class="badge badge-success" *ngIf="otac.status == 'free'">free</span>
-                        <span class="badge badge-info" *ngIf="otac.status == 'taken'">taken</span>
-                    </clr-dg-cell>
-                    <clr-dg-cell>{{ otac.name }}</clr-dg-cell>
-                    <clr-dg-cell>{{ otac.userEmail }}</clr-dg-cell>
-                    <clr-dg-cell>{{ otac.redeemed_timestamp }}</clr-dg-cell>
-                    <clr-dg-cell *rbac="['scheduledevents.update']">
-                        <button type="button" class="btn btn-warning-outline" (click)="deleteOtac(otac)">
-                            Delete
-                        </button>
-                    </clr-dg-cell>
-                </clr-dg-row>
-
-                <clr-dg-footer>{{ getOverallInfo() }}</clr-dg-footer>
-            </clr-datagrid>
-        </div>
+        <clr-dg-footer>{{ getOverallInfo() }}</clr-dg-footer>
+      </clr-datagrid>
     </div>
-    <div class="modal-footer">
-        <button type="button" class="btn btn-primary" (click)="exportCSV()">
-            Export to csv
-        </button>
-        <button type="button" class="btn btn-flat-primary" (click)="close()">
-            Close
-        </button>
-    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" (click)="exportCSV()">
+      Export to csv
+    </button>
+    <button type="button" class="btn btn-flat-primary" (click)="close()">
+      Close
+    </button>
+  </div>
 </clr-modal>

--- a/src/app/event/otacmanagement/otacmanagement.component.scss
+++ b/src/app/event/otacmanagement/otacmanagement.component.scss
@@ -1,26 +1,30 @@
 .datagrid-container {
-    height: 60vh;
-    max-height: 60vh
+  height: 60vh;
+  max-height: 60vh;
 }
 
 .datagrid-container clr-datagrid {
-    max-height: 100%;
+  max-height: 100%;
 }
 
 .flexbox {
-    display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    align-items: center;
-    height: fit-content;
-    width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  height: fit-content;
+  width: 100%;
 }
 
 .input-container {
-    width: min-content;
-    padding-right: 2vw;
+  width: min-content;
+  padding-right: 2vw;
 }
 
 .flexbox * {
-    margin: 0;
+  margin: 0;
+}
+
+.otac-label.clr-col-md-2 {
+  max-width: fit-content;
 }

--- a/src/app/event/otacmanagement/otacmanagement.component.ts
+++ b/src/app/event/otacmanagement/otacmanagement.component.ts
@@ -40,15 +40,10 @@ export class OTACManagementComponent implements OnInit, OnDestroy {
   currentScheduledEvent: ScheduledEvent = null;
 
   // The Validator Pattern for the duration only accepts strings that make up a valid duration
-  // For example "1d2h3m" for 1 day, 2 hours and 3 minutes
-  // "30m1d" would not be allowed because the highest gratitude has to be stated first
-  // Any single "1d", "20h", "30m" or any combination "1d20h" is also allowed
-  // "1d2d" would also not be allowed because of day being stated twice.
+  // For example "1d" for 1 day, "24h" for 24 Hours, "60m" for 60 minutes.
   amountInputForm: FormGroup = new FormGroup({
     amountInput: new FormControl(1, [Validators.required, Validators.min(1)]),
-    duration: new FormControl('', [
-      Validators.pattern(/^(\d+[d]){0,1}(\d+[h]){0,1}(\d+[m]){0,1}$/),
-    ]),
+    duration: new FormControl('', [Validators.pattern(/^(\d+[dhm]){1}$/)]),
   });
 
   amountNewOtacs: number = 1;


### PR DESCRIPTION


- It adds all changes needed to display the duration, introducing a new status label "out-of-time" as well as allowing the admin to set the duration when creating OTACs.
See:
![otac_modal](https://github.com/hobbyfarm/admin-ui/assets/86782124/9c3019d9-6972-471b-b44f-a859b34fb321)
- Modifying any existing duration is not yet part of this implementation as this might not be needed
- Added https://www.npmjs.com/package/parse-duration to parse time durations like "1d20m"
- Changed CSV export to print duration as well as the current status

This PR comes along with https://github.com/hobbyfarm/gargantua/pull/177