### PR TITLE
Display user and scenario id instead of None

### DIFF
--- a/src/app/dashboards/progress-dashboard/progress-dashboard.component.ts
+++ b/src/app/dashboards/progress-dashboard/progress-dashboard.component.ts
@@ -139,9 +139,9 @@ export class ProgressDashboardComponent implements OnInit {
 
       this.currentProgress = progressList.map((element) => ({
         ...element,
-        username: userMap.get(element.user) ?? 'none',
-        scenario_name: scenarioMap.get(element.scenario) ?? 'none',
-        course_name: courseMap.get(element.course) ?? '',
+        username: userMap.get(element.user) ?? element.user,
+        scenario_name: scenarioMap.get(element.scenario) ?? element.scenario,
+        course_name: courseMap.get(element.course) ?? element.course,
       }));
       this.users = users.filter(
         (user) =>


### PR DESCRIPTION
When the user is not in the local cached users list "None" will be displayed. Same for the scenario name. 
It is easier when the user id and scenari ids are displayed.