### PR TITLE
Add hide usernames button to dashboard for privacy on screensharings

### DIFF
--- a/src/app/dashboards/progress-dashboard/progress-dashboard.component.html
+++ b/src/app/dashboards/progress-dashboard/progress-dashboard.component.html
@@ -19,6 +19,20 @@
               >Whether finished sessions should be included.
             </clr-control-helper>
           </clr-toggle-container>
+          <clr-toggle-container id="hideUsernamesToggle">
+            <clr-toggle-wrapper>
+              <input
+                type="checkbox"
+                clrToggle
+                name="hideUsernames"
+                [(ngModel)]="hideUsernames"
+              />
+              <label>Hide Usernames</label>
+            </clr-toggle-wrapper>
+            <clr-control-helper
+              >Keep names hidden in screensharings
+            </clr-control-helper>
+          </clr-toggle-container>
         </div>
         <div class="clr-col">
           <input
@@ -104,6 +118,7 @@
         <progress-card
           [progress]="p"
           [pause]="pause"
+          [hideUsername]="hideUsernames"
           (nameClickedEvent)="filterName($event)"
         ></progress-card>
       </div>

--- a/src/app/dashboards/progress-dashboard/progress-dashboard.component.ts
+++ b/src/app/dashboards/progress-dashboard/progress-dashboard.component.ts
@@ -26,6 +26,7 @@ export class ProgressDashboardComponent implements OnInit {
   public callInterval: any;
   public circleVisible: boolean = true;
   public users: User[];
+  public hideUsernames: boolean = false;
 
   public pauseCall: boolean = false; // Stop refreshing if we are looking at a progress
   public pause = (pause: boolean) => {

--- a/src/app/progress/progress.component.html
+++ b/src/app/progress/progress.component.html
@@ -1,40 +1,85 @@
 <div class="card">
-    <div class="progress">
-        <progress class="{{getProgressColorClass()}}" [value]="getProgress() || 0" max="100"></progress>
+  <div class="progress">
+    <progress
+      class="{{ getProgressColorClass() }}"
+      [value]="getProgress() || 0"
+      max="100"
+    ></progress>
+  </div>
+
+  <div class="card-header" (click)="progressFilterName()">
+    {{ getUsername() }}
+  </div>
+  <div class="card-block">
+    <div class="card-text">
+      <div>
+        <cds-icon shape="play" solid></cds-icon> {{ progress.scenario_name }}
+      </div>
+      <div *ngIf="progress.course">
+        <cds-icon shape="layers" solid></cds-icon> {{ progress.course_name }}
+      </div>
+      <div *ngIf="progress.current_step > 0">
+        <cds-icon shape="number-list"></cds-icon> {{ progress.current_step }} /
+        {{ progress.total_step }}
+      </div>
+      <div *ngIf="progress.current_step == 0">
+        <cds-icon shape="number-list"></cds-icon> Not started yet
+      </div>
+      <div *ngIf="!progress.finished" title="Since {{ progress.started }}">
+        <cds-icon shape="clock"></cds-icon> {{ timeSince(progress.started) }}
+      </div>
+      <div
+        *ngIf="progress.finished"
+        title="{{ progress.started }}-{{ progress.last_update }}"
+      >
+        <cds-icon shape="clock"></cds-icon>
+        {{ timeSince(progress.started, progress.last_update) }}
+      </div>
     </div>
-    
-    <div class="card-header" (click)="progressFilterName()">
-        {{ progress.username }}
-    </div>
-    <div class="card-block">
-        <div class="card-text">
-            <div><cds-icon shape="play" solid></cds-icon> {{progress.scenario_name}}</div>
-            <div *ngIf="progress.course"><cds-icon shape="layers" solid></cds-icon> {{progress.course_name}}</div>
-            <div *ngIf="progress.current_step > 0"><cds-icon shape="number-list"></cds-icon> {{ progress.current_step }} / {{ progress.total_step }}</div>
-            <div *ngIf="progress.current_step == 0"><cds-icon shape="number-list"></cds-icon> Not started yet</div>
-            <div *ngIf="!progress.finished" title="Since {{progress.started}}"><cds-icon shape="clock"></cds-icon> {{  timeSince(progress.started) }}</div>
-            <div *ngIf="progress.finished" title="{{progress.started}}-{{progress.last_update}}"><cds-icon shape="clock"></cds-icon> {{  timeSince(progress.started, progress.last_update) }}</div>
+  </div>
+
+  <div class="card-footer">
+    <clr-dropdown>
+      <button class="dropdown-toggle btn btn-primary" clrDropdownTrigger>
+        Actions
+        <cds-icon shape="angle" direction="down"></cds-icon>
+      </button>
+      <clr-dropdown-menu clrPosition="top-left" *clrIfOpen>
+        <div class="dropdown-item" (click)="openInfo()" clrDropdownItem>
+          Info
         </div>
-    </div>
-
-    
-
-
-    <div class="card-footer">
-
-        <clr-dropdown>
-            <button class="dropdown-toggle btn btn-primary" clrDropdownTrigger>
-                Actions
-                <cds-icon shape="angle" direction="down"></cds-icon>
-            </button>
-            <clr-dropdown-menu clrPosition="top-left" *clrIfOpen>
-                <div class="dropdown-item " (click)="openInfo()" clrDropdownItem>Info</div>                
-                <div class="dropdown-item"  (click)="openTerminalWindow()" [clrDisabled]="progress.finished" clrDropdownItem *rbac="['sessions.get', 'courses.get','progresses.list', 'scenarios.get', 'virtualmachineclaims.get']">Join Session</div>
-                <div class="dropdown-divider" role="separator" aria-hidden="true"></div>
-                <div class="dropdown-item " (click)="terminateSession()" [clrDisabled]="progress.finished" clrDropdownItem *rbac="['sessions.update']">Terminate Session</div>
-            </clr-dropdown-menu>
-        </clr-dropdown>
-    </div>
+        <div
+          class="dropdown-item"
+          (click)="openTerminalWindow()"
+          [clrDisabled]="progress.finished"
+          clrDropdownItem
+          *rbac="[
+            'sessions.get',
+            'courses.get',
+            'progresses.list',
+            'scenarios.get',
+            'virtualmachineclaims.get'
+          ]"
+        >
+          Join Session
+        </div>
+        <div class="dropdown-divider" role="separator" aria-hidden="true"></div>
+        <div
+          class="dropdown-item"
+          (click)="terminateSession()"
+          [clrDisabled]="progress.finished"
+          clrDropdownItem
+          *rbac="['sessions.update']"
+        >
+          Terminate Session
+        </div>
+      </clr-dropdown-menu>
+    </clr-dropdown>
+  </div>
 </div>
 
-<progress-info #progressInfo [progress]="progress" [pause]="pause"></progress-info>
+<progress-info
+  #progressInfo
+  [progress]="progress"
+  [pause]="pause"
+></progress-info>

--- a/src/app/progress/progress.component.ts
+++ b/src/app/progress/progress.component.ts
@@ -23,6 +23,9 @@ export class ProgressComponent {
   public progress: Progress;
 
   @Input()
+  public hideUsername: boolean;
+
+  @Input()
   public pause: Function;
 
   @Output() nameClickedEvent = new EventEmitter<string>();
@@ -93,5 +96,9 @@ export class ProgressComponent {
       return 'status-success';
     }
     return 'status-running';
+  }
+
+  public getUsername() {
+    return this.hideUsername ? this.progress.user : this.progress.username;
   }
 }


### PR DESCRIPTION
fixes https://github.com/hobbyfarm/hobbyfarm/issues/425


Adds a "hide usernames" button to the progress dashboard to allow screensharing without providing usernames. When the toggle is enabled the user id will be shown instead.