### PR TITLE
Add new proxy configuration options

### DIFF
--- a/src/app/configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component.html
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component.html
@@ -146,6 +146,13 @@
               formControlName="path"
             />
           </clr-input-container>
+          <clr-select-container>
+            <label>Protocol</label>
+            <select title="protocol" clrSelect formControlName="protocol">
+              <option value="http">http</option>
+              <option value="https">https</option>
+            </select>
+          </clr-select-container>
           <clr-accordion class="advanced-settings">
             <clr-accordion-panel>
               <clr-accordion-title>Advanced Proxy Options</clr-accordion-title>
@@ -239,6 +246,29 @@
                         <cds-icon shape="info-circle" size="24"></cds-icon>
                         <span class="tooltip-content"
                           >Force opening inside a new tab</span
+                        >
+                      </a>
+                    </label>
+                  </clr-checkbox-wrapper>
+                  <clr-checkbox-wrapper>
+                    <input
+                      type="checkbox"
+                      clrCheckbox
+                      value="disableAuthorizationHeader"
+                      name="disableAuthorizationHeader"
+                      formControlName="disableAuthorizationHeader"
+                    />
+                    <label
+                      >Disable Authorization Header
+                      <a
+                        role="tooltip"
+                        aria-haspopup="true"
+                        class="tooltip tooltip-md tooltip-top-right"
+                      >
+                        <cds-icon shape="info-circle" size="24"></cds-icon>
+                        <span class="tooltip-content"
+                          >Disable the authorization header for proxied
+                          requests</span
                         >
                       </a>
                     </label>

--- a/src/app/configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component.ts
+++ b/src/app/configuration/vmtemplates/edit-vmtemplate/vmtemplate-service-form/vmtemplate-service-form.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { FormControl, FormGroup, NonNullableFormBuilder } from '@angular/forms';
 import { CloudInitConfig } from 'src/app/data/cloud-init-config';
 import { PredefinedServiceService } from 'src/app/data/predefinedservice.service';
+import { Protocol } from 'src/app/data/protocol';
 import {
   getCloudConfigString,
   VMTemplateServiceConfiguration,
@@ -24,11 +25,13 @@ export class VMTemplateServiceFormComponent implements OnInit {
     name: FormControl<string>;
     port: FormControl<number>;
     path: FormControl<string>;
+    protocol: FormControl<Protocol>;
     hasOwnTab: FormControl<boolean>;
     noPathRewriting: FormControl<boolean>;
     proxyHostHeaderRewriting: FormControl<boolean>;
     proxyOriginHeaderRewriting: FormControl<boolean>;
     disallowIFrame: FormControl<boolean>;
+    disableAuthorizationHeader: FormControl<boolean>;
     cloudConfigString: FormControl<string>;
     hasWebinterface: FormControl<boolean>;
   }>;
@@ -88,6 +91,9 @@ export class VMTemplateServiceFormComponent implements OnInit {
       path: this.fb.control<string>(
         edit ? this.editVMService.path ?? this.DEFAULT_PATH : this.DEFAULT_PATH
       ),
+      protocol: this.fb.control<Protocol>(
+        edit ? this.editVMService.protocol ?? 'http' : 'http'
+      ),
       hasOwnTab: this.fb.control<boolean>(
         edit ? this.editVMService.hasOwnTab : false
       ),
@@ -102,6 +108,9 @@ export class VMTemplateServiceFormComponent implements OnInit {
       ),
       disallowIFrame: this.fb.control<boolean>(
         edit ? this.editVMService.disallowIFrame : true
+      ),
+      disableAuthorizationHeader: this.fb.control<boolean>(
+        edit ? this.editVMService.disableAuthorizationHeader : true
       ),
       cloudConfigString: this.fb.control<string>(
         edit ? getCloudConfigString(this.editVMService) : ''
@@ -131,6 +140,7 @@ export class VMTemplateServiceFormComponent implements OnInit {
       this.newVMServiceFormGroup.controls.hasWebinterface.value;
     newVMService.port = this.newVMServiceFormGroup.controls.port.value;
     newVMService.path = this.newVMServiceFormGroup.controls.path.value;
+    newVMService.protocol = this.newVMServiceFormGroup.controls.protocol.value;
     newVMService.hasOwnTab =
       this.newVMServiceFormGroup.controls.hasOwnTab.value;
     newVMService.noRewriteRootPath =
@@ -139,6 +149,8 @@ export class VMTemplateServiceFormComponent implements OnInit {
       this.newVMServiceFormGroup.controls.proxyHostHeaderRewriting.value;
     newVMService.rewriteOriginHeader =
       this.newVMServiceFormGroup.controls.proxyOriginHeaderRewriting.value;
+    newVMService.disableAuthorizationHeader =
+      this.newVMServiceFormGroup.controls.disableAuthorizationHeader.value;
     newVMService.disallowIFrame =
       this.newVMServiceFormGroup.controls.disallowIFrame.value;
     newVMService.cloudConfigString =

--- a/src/app/data/predefinedservice.service.ts
+++ b/src/app/data/predefinedservice.service.ts
@@ -6,33 +6,33 @@ import { map, switchMap, tap, combineLatestAll } from 'rxjs/operators';
 import { BehaviorSubject, from, of } from 'rxjs';
 import { atou } from '../unicode';
 import { VMTemplateServiceConfiguration } from './vm-template-service-configuration';
-
+import { Protocol } from './protocol';
 
 interface IVMTemplateServiceConfiguration {
-  has_webinterface?: boolean,
-  has_tab?: boolean,
-  no_rewrite_root_path?: boolean,
-  rewrite_host_header?: boolean,
-  rewrite_origin_header?: boolean,
-  disallow_iframe?: boolean,
-  cloud_config?: string,
-  name: string,
-  port?: number,
-  path?: string,
+  has_webinterface?: boolean;
+  has_tab?: boolean;
+  no_rewrite_root_path?: boolean;
+  rewrite_host_header?: boolean;
+  rewrite_origin_header?: boolean;
+  disallow_iframe?: boolean;
+  disable_authorization_header?: boolean;
+  cloud_config?: string;
+  name: string;
+  port?: number;
+  path?: string;
+  protocol?: Protocol;
 }
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class PredefinedServiceService {
-
   private cachedList: VMTemplateServiceConfiguration[] = [];
-  private bh: BehaviorSubject<VMTemplateServiceConfiguration[]> = new BehaviorSubject(this.cachedList);
+  private bh: BehaviorSubject<VMTemplateServiceConfiguration[]> =
+    new BehaviorSubject(this.cachedList);
   private fetchedList = false;
 
-  constructor(
-    public http: HttpClient
-  ) { }
+  constructor(public http: HttpClient) {}
 
   public watch() {
     return this.bh.asObservable();
@@ -42,31 +42,33 @@ export class PredefinedServiceService {
     if (!force && this.fetchedList) {
       return of(this.cachedList);
     } else {
-      return this.http.get(environment.server + '/a/predefinedservices/list')
+      return this.http
+        .get(environment.server + '/a/predefinedservices/list')
         .pipe(
           switchMap((s: ServerResponse) => {
             return from(JSON.parse(atou(s.content)));
           }),
           map((resp: IVMTemplateServiceConfiguration) => {
             let parsedVmtsc = new VMTemplateServiceConfiguration(
-              resp.name, 
-              resp.has_webinterface, 
-              resp.port, 
-              resp.path, 
-              resp.has_tab, 
-              resp.no_rewrite_root_path, 
-              resp.rewrite_host_header, 
-              resp.rewrite_origin_header, 
-              resp.disallow_iframe, 
+              resp.name,
+              resp.has_webinterface,
+              resp.port,
+              resp.path,
+              resp.protocol,
+              resp.has_tab,
+              resp.no_rewrite_root_path,
+              resp.rewrite_host_header,
+              resp.rewrite_origin_header,
+              resp.disallow_iframe,
+              resp.disable_authorization_header,
               resp.cloud_config
-              )
+            );
             return of(parsedVmtsc);
           }),
           combineLatestAll(),
           tap((vmtsc: VMTemplateServiceConfiguration[]) => {
             this.set(vmtsc);
-          }
-          ),
+          })
         );
     }
   }

--- a/src/app/data/protocol.ts
+++ b/src/app/data/protocol.ts
@@ -1,0 +1,1 @@
+export type Protocol = 'http' | 'https';

--- a/src/app/data/vm-template-service-configuration.ts
+++ b/src/app/data/vm-template-service-configuration.ts
@@ -1,16 +1,19 @@
 import YAML from 'yaml';
-import * as uuid from 'uuid'
+import * as uuid from 'uuid';
+import { Protocol } from './protocol';
 export class VMTemplateServiceConfiguration {
   public id: string;
   public name: string;
   public hasWebinterface: boolean;
   public port?: number;
   public path?: string;
+  public protocol?: Protocol;
   public hasOwnTab?: boolean;
   public noRewriteRootPath?: boolean;
   public rewriteHostHeader?: boolean;
   public rewriteOriginHeader?: boolean;
   public disallowIFrame?: boolean;
+  public disableAuthorizationHeader: boolean;
   public cloudConfigMap?: Map<string, Object>;
   public cloudConfigString?: string;
 
@@ -19,23 +22,27 @@ export class VMTemplateServiceConfiguration {
     hasWebinterface = false,
     port: number = -1,
     path: string = '/',
+    protocol: Protocol = 'http',
     hasOwnTab: boolean = false,
     noRewriteRootPath: boolean = false,
     rewriteHostHeader: boolean = true,
     rewriteOriginHeader: boolean = false,
     disallowIFrame: boolean = false,
+    disableAuthorizationHeader: boolean = false,
     cloudConfigString: string = ''
   ) {
-    this.id = uuid.v4()
+    this.id = uuid.v4();
     this.name = name;
     this.hasWebinterface = hasWebinterface;
     this.port = port;
     this.path = path;
+    this.protocol = protocol;
     this.hasOwnTab = hasOwnTab;
     this.noRewriteRootPath = noRewriteRootPath;
     this.rewriteHostHeader = rewriteHostHeader;
     this.rewriteOriginHeader = rewriteOriginHeader;
     this.disallowIFrame = disallowIFrame;
+    this.disableAuthorizationHeader = disableAuthorizationHeader;
     this.cloudConfigString = cloudConfigString;
     this.cloudConfigMap = new Map();
     if (this.cloudConfigString.length > 0) {
@@ -59,7 +66,9 @@ export function getCloudConfigString(
 
 export function vmServiceToJSON(vmService: VMTemplateServiceConfiguration) {
   let result =
-    '{"id" : "' + vmService.id + '" , "name": "' +
+    '{"id" : "' +
+    vmService.id +
+    '" , "name": "' +
     vmService.name +
     '" ,"hasWebinterface": ' +
     vmService.hasWebinterface;
@@ -71,6 +80,9 @@ export function vmServiceToJSON(vmService: VMTemplateServiceConfiguration) {
     }
     if (vmService.path) {
       result += ', "path": ' + JSON.stringify(vmService.path);
+    }
+    if (vmService.protocol) {
+      result += ', "protocol": ' + JSON.stringify(vmService.protocol);
     }
     if (vmService.hasOwnTab) {
       result += ', "hasOwnTab": ' + vmService.hasOwnTab;
@@ -84,31 +96,42 @@ export function vmServiceToJSON(vmService: VMTemplateServiceConfiguration) {
     if (vmService.disallowIFrame) {
       result += ', "disallowIFrame": ' + vmService.disallowIFrame;
     }
+    if (vmService.disableAuthorizationHeader) {
+      result +=
+        ', "disableAuthorizationHeader": ' +
+        vmService.disableAuthorizationHeader;
+    }
     if (vmService.noRewriteRootPath) {
       result += ', "noRewriteRootPath": ' + vmService.noRewriteRootPath;
     }
   }
-  if (vmService.cloudConfigMap) {   
-    result += ', "cloudConfigMap": {' + mapToJson(vmService.cloudConfigMap, '') + '}'; //Potential alternative if es2019 or higher (configurable in tsconfig, field: lib): JSON.stringify(Object.fromEntries(vmService.cloudConfigMap))
+  if (vmService.cloudConfigMap) {
+    result +=
+      ', "cloudConfigMap": {' + mapToJson(vmService.cloudConfigMap, '') + '}'; //Potential alternative if es2019 or higher (configurable in tsconfig, field: lib): JSON.stringify(Object.fromEntries(vmService.cloudConfigMap))
   }
   result += '}';
   return result;
 }
 
 export function mapToJson(map: Map<string, any>, jsonString: string): string {
-  let isfirstElement = true
+  let isfirstElement = true;
   map.forEach((value, key) => {
-    if(!isfirstElement) {
-      jsonString += ','
+    if (!isfirstElement) {
+      jsonString += ',';
     }
-    if(typeof value === 'string' || Array.isArray(value)) {
+    if (typeof value === 'string' || Array.isArray(value)) {
       jsonString += '"' + key + '": ' + JSON.stringify(value) + ' ';
-    } else if (value instanceof Map){
+    } else if (value instanceof Map) {
       jsonString += '"' + key + '": {' + mapToJson(value, '') + '} ';
     } else {
-      jsonString += '"' + key + '": {' + mapToJson(new Map(Object.entries(value)), '') + '} ';
+      jsonString +=
+        '"' +
+        key +
+        '": {' +
+        mapToJson(new Map(Object.entries(value)), '') +
+        '} ';
     }
-    isfirstElement = false
+    isfirstElement = false;
   });
-  return jsonString
+  return jsonString;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements two new proxy options, specifying a protocol (http or https) and disabling the Authorization Header for proxied requests. 

#### Milestones - General Tasks
- [x] Implement a dropdown to select the protocol - default: http
- [x] Implement a checkbox to enable/disable the Authorization Header for proxied requests