### PR TITLE
Fix for Issue 468 - no success message on changing admin configurations

### DIFF
--- a/src/app/configuration/settings/settings.component.html
+++ b/src/app/configuration/settings/settings.component.html
@@ -8,7 +8,7 @@
     </h3>
   </div>
 </div>
-<clr-alert #alert [(clrAlertClosed)]="alertClosed"></clr-alert>
+<alert #alert></alert>
 
 <button class="btn" (click)="onSubmit()" [disabled]="!hasChanges || !valid">
   Save Changes

--- a/src/app/configuration/settings/settings.component.ts
+++ b/src/app/configuration/settings/settings.component.ts
@@ -28,7 +28,6 @@ export class SettingsComponent {
 
   private alertTime = 2000;
   private alertErrorTime = 10000;
-  public alertClosed: boolean = true;
 
   constructor(
     public typedSettingsService: TypedSettingsService,
@@ -61,7 +60,7 @@ export class SettingsComponent {
         this.hasChanges = false;
         this.alert.success(
           'Settings successfully saved',
-          false,
+          true,
           this.alertTime
         );
       },


### PR DESCRIPTION
Now a success message is shown by changing admin configurations. Instead of the AlertComponent another alert type was used, that had no function "success". Now the correct type is used and die message is displayed